### PR TITLE
Update Azure_Pass_HowTo-zho-HK

### DIFF
--- a/Translations/zh/Azure_Pass_HowTo-zho-HK
+++ b/Translations/zh/Azure_Pass_HowTo-zho-HK
@@ -63,7 +63,7 @@
 
     !IMAGE[](https://lodmanuals.blob.core.windows.net/manuals/LODS%20Media/Azure%20Pass%20How-To/Updated_04_28_2020/9.jpg)
     
-单击下方的 **下一个 >** 以继续。
+单击下方的 **下一步”** 以继续。
 
 [azure-pass]:
 ```


### PR DESCRIPTION
ESI says the character **下一个 >** is the incorrect translation for Next. 
It should be **下一步”**