### PR TITLE
Update Azure_Pass_HowTo-jpn

### DIFF
--- a/Translations/JA/Azure_Pass_HowTo-jpn
+++ b/Translations/JA/Azure_Pass_HowTo-jpn
@@ -14,7 +14,7 @@ Azure Passサブスクリプションの作成は2つの手順で行います。
 
 ## 手順1：Microsoft Azure Passプロモコード(Promo Code)の引き換え：
 
-1. [] ブラウザを開いて次にナビゲートします：@[www.microsoftazurepass.com][azure-pass]{powershell}
+1. [] ブラウザを開いて次にナビゲートします： +++https://www.microsoftazurepass.com/+++
 
     > [!KNOWLEDGE] すべてのブラウザを閉じ、新規にIn-Privateブラウザセッションを開いてください。その他のログインはアクティブ化手順中に持続し、エラーを発生させる可能性があります。
 


### PR DESCRIPTION
https://www.microsoftazurepass.com link changed to type text. since its no longer working as a PowerShell command. All other instances of Azure Pass how to show  +++https://www.microsoftazurepass.com/+++ as the md for the link.