### PR TITLE
Update Azure_Pass_HowTo-kor

### DIFF
--- a/Translations/ko/Azure_Pass_HowTo-kor
+++ b/Translations/ko/Azure_Pass_HowTo-kor
@@ -12,7 +12,7 @@ Azure Pass 구독 생성은 2단계 과정입니다.
 
 ## 1단계: Microsoft Azure Pass 프로모션 코드 교환:
 
-1. [] 브라우저를 열고 다음으로 이동합니다. @[www.microsoftazurepass.com][azure-pass]{powershell}
+1. [] 브라우저를 열고 다음으로 이동합니다.  +++https://www.microsoftazurepass.com/+++
 
     > [!KNOWLEDGE] 모든 브라우저를 닫고 새로운 In-Private 브라우저 세션을 열어주세요. 다른 로그인이 유지되면 활성화 단계에서 에러가 발생할 수 있습니다.
 


### PR DESCRIPTION
https://www.microsoftazurepass.com link changed to type text. since its no longer working as a PowerShell command. All other instances of Azure Pass how to show  +++https://www.microsoftazurepass.com/+++ as the md for the link.