### PR TITLE
Update Azure_Pass_HowTo-zho-HK

### DIFF
--- a/Translations/zh/Azure_Pass_HowTo-zho-HK
+++ b/Translations/zh/Azure_Pass_HowTo-zho-HK
@@ -14,7 +14,7 @@
 
 ## 步骤 1：兑换 Microsoft Azure 通行证优惠代码：
 
-1. [] 打开浏览器并导航至：@[www.microsoftazurepass.com][azure-pass]{powershell}
+1. [] 打开浏览器并导航至： +++https://www.microsoftazurepass.com/+++
 
     > [!KNOWLEDGE] 建议您关闭所有浏览器，然后打开一个新的隐私模式浏览器会话。在激活过程中，可能会一直存在其他的登录并导致出错。
 


### PR DESCRIPTION
https://www.microsoftazurepass.com link changed to type text. since its no longer working as a PowerShell command. All other instances of Azure Pass how to show  +++https://www.microsoftazurepass.com/+++ as the md for the link.