### PR TITLE
Update Azure_Pass_HowTo-jpn

### DIFF
--- a/Translations/JA/Azure_Pass_HowTo-jpn
+++ b/Translations/JA/Azure_Pass_HowTo-jpn
@@ -60,7 +60,7 @@ Azure Passサブスクリプションの作成は2つの手順で行います。
 
     !IMAGE[](https://lodmanuals.blob.core.windows.net/manuals/LODS%20Media/Azure%20Pass%20How-To/Updated_04_28_2020/9.jpg)
     
-下の **次に >** クリックして続けます。
+下の **次 >** クリックして続けます。
 
 [azure-pass]:
 ```


### PR DESCRIPTION
Removing JA char called out by QA that does not match the 'Next' button as seen in our UI.